### PR TITLE
chore(`CI/CD`): osx dmg build workflow

### DIFF
--- a/.github/workflows/build_mac_dmg.yml
+++ b/.github/workflows/build_mac_dmg.yml
@@ -1,0 +1,35 @@
+name: macOS CI Test
+
+  on:
+    # Triggers the workflow on pull request events but only for the "master" branch
+    pull_request:
+      branches: ['master']
+
+  jobs:
+    # This workflow contains a single job called "build"
+    build:
+      runs-on: macos-latest
+
+      steps:
+        # Checks-out repository under $GITHUB_WORKSPACE
+        - uses: actions/checkout@v3
+
+        - name: Install build time dependencies
+          run: brew install autoconf automake libtool gettext coreutils pkgconfig
+
+        - name: Run make_libsecp256k1.sh and make_osx build scripts
+          run: ./contrib/make_libsecp256k1.sh && ./contrib/osx/make_osx
+
+        - name: Release without Tags
+          uses: softprops/action-gh-release@v1
+          if: ${{ github.ref_type	!= 'tag' }}
+          with:
+            name: ${{ github.head_ref }}
+            tag_name: ${{ github.head_ref }}
+            files: './dist/*.dmg'
+
+        - name: Release with Tags
+          uses: softprops/action-gh-release@v1
+          if: startsWith(github.ref, 'refs/tags/')
+          with:
+            files: './dist/*.dmg'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Cherry picked GA workflow. To run downstream [PR](https://github.com/BirthdayResearch/defichain-electrum/pull/11) build script before merge.

#### Additional comments?:
